### PR TITLE
Dogfood 'outil' to add some flags and print usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,10 @@ You can run it locally with Docker:
 
 ```shell session
 $ docker run --rm -p3000:3000 -it ghcr.io/fabjan/buildogram:latest
-Unable to find image 'ghcr.io/fabjan/buildogram:latest' locally
-latest: Pulling from fabjan/buildogram
-ca7dd9ec2225: Already exists 
-e5c19fb42d85: Already exists 
-649443606315: Pull complete 
-4f4fb700ef54: Pull complete 
-Digest: sha256:4d2ea97f8efcf8c397ad8b711ee4d6b7a101ae4b5376c743e91fe0095136f4b4
-Status: Downloaded newer image for ghcr.io/fabjan/buildogram:latest
-[main] 🛠  Default port: 3000
-[main] 🛠  Default cache size: 100
+[main] 🛠 HTTP cache item limit: 100
 [main] ✨ Buildogram is now listening on :3000
-[main] Use Ctrl+C to break
+[main] Use Ctrl+C, Ctrl+C to stop.
 ```
-
-You will have to press Ctrl+C twice to exit.
 
 Try fetching the diagram from another terminal:
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -2,11 +2,11 @@ name = "buildogram"
 version = "0.1.0"
 
 licences = ["Apache-2.0"]
-description = "An application that keeps track of and displays build pipeline statistics."
+description = "An application that displays build pipeline statistics."
 repository = { type = "github", user = "fabjan", repo = "buildogram" }
 
 [dependencies]
-gleam_stdlib = "~> 0.24"
+gleam_stdlib = "~> 0.26"
 gleam_erlang = "~> 0.17"
 gleam_elli = "~> 2.0"
 gleam_http = "~> 3.1"
@@ -14,6 +14,7 @@ gleam_json = "~> 0.5"
 gleam_hackney = "~> 0.2"
 snag = "~> 0.2"
 gleam_otp = "~> 0.5"
+outil = "~> 0.3.3"
 
 [dev-dependencies]
 gleeunit = "~> 0.6"

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,22 +4,23 @@
 packages = [
   { name = "certifi", version = "2.9.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "266DA46BDB06D6C6D35FDE799BCB28D36D985D424AD7C08B5BB48F5B5CDD4641" },
   { name = "elli", version = "3.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "elli", source = "hex", outer_checksum = "698B13B33D05661DB9FE7EFCBA41B84825A379CCE86E486CF6AFF9285BE0CCF8" },
-  { name = "gleam_elli", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "elli", "gleam_http", "gleam_otp"], otp_app = "gleam_elli", source = "hex", outer_checksum = "5DB2D8F83DF2A7384C5F381CCC837042EFB00272E9E5A01A071CC7600E2D6978" },
-  { name = "gleam_erlang", version = "0.17.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A3BB3D4A6AFC2E34CAB1A4960F0CBBC4AA1A052D5023477D16B848D86E69948A" },
-  { name = "gleam_hackney", version = "0.2.1", build_tools = ["gleam"], requirements = ["hackney", "gleam_http", "gleam_stdlib"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "CCACA00027C827436D8EB945651392B6E5798CFC9E69907A28BE61832B0C02A4" },
+  { name = "gleam_elli", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_otp", "gleam_http", "elli", "gleam_stdlib"], otp_app = "gleam_elli", source = "hex", outer_checksum = "5DB2D8F83DF2A7384C5F381CCC837042EFB00272E9E5A01A071CC7600E2D6978" },
+  { name = "gleam_erlang", version = "0.18.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "14ABC93A7975369CCDDC0C4D9A34C0E0FE99CA3AD336BE6A17299EC0285B7107" },
+  { name = "gleam_hackney", version = "0.2.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "CCACA00027C827436D8EB945651392B6E5798CFC9E69907A28BE61832B0C02A4" },
   { name = "gleam_http", version = "3.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "B66B7A1539CCB577119E4DC80DD3484C1A652CB032967954498EEDBAE3355763" },
   { name = "gleam_json", version = "0.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "E42443C98AA66E30143C24818F2CEA801491C10CE6B1A5EDDF3FC4ABDC7601CB" },
   { name = "gleam_otp", version = "0.5.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_erlang"], otp_app = "gleam_otp", source = "hex", outer_checksum = "24B88BF1D5B8DEC2525C00ECB65B96D2FD4DC66D8B2BB4D7AD4D12B2CE2A9988" },
-  { name = "gleam_stdlib", version = "0.25.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "AD0F89928E0B919C8F8EDF640484633B28DBF88630A9E6AE504617A3E3E5B9A2" },
-  { name = "gleeunit", version = "0.7.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "5F4FBED3E93CDEDB0570D30E9DECB7058C2D327996B78BB2D245C739C7136010" },
-  { name = "hackney", version = "1.18.1", build_tools = ["rebar3"], requirements = ["unicode_util_compat", "metrics", "mimerl", "ssl_verify_fun", "parse_trans", "certifi", "idna"], otp_app = "hackney", source = "hex", outer_checksum = "A4ECDAFF44297E9B5894AE499E9A070EA1888C84AFDD1FD9B7B2BC384950128E" },
+  { name = "gleam_stdlib", version = "0.26.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "B17BBE8A78F3909D93BCC6C24F531673A7E328A61F24222EB1E58D0A7552B1FE" },
+  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
+  { name = "hackney", version = "1.18.1", build_tools = ["rebar3"], requirements = ["metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat", "certifi", "idna"], otp_app = "hackney", source = "hex", outer_checksum = "A4ECDAFF44297E9B5894AE499E9A070EA1888C84AFDD1FD9B7B2BC384950128E" },
   { name = "idna", version = "6.1.1", build_tools = ["rebar3"], requirements = ["unicode_util_compat"], otp_app = "idna", source = "hex", outer_checksum = "92376EB7894412ED19AC475E4A86F7B413C1B9FBB5BD16DCCD57934157944CEA" },
   { name = "metrics", version = "1.0.1", build_tools = ["rebar3"], requirements = [], otp_app = "metrics", source = "hex", outer_checksum = "69B09ADDDC4F74A40716AE54D140F93BEB0FB8978D8636EADED0C31B6F099F16" },
   { name = "mimerl", version = "1.2.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "F278585650AA581986264638EBF698F8BB19DF297F66AD91B18910DFC6E19323" },
+  { name = "outil", version = "0.3.3", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "outil", source = "hex", outer_checksum = "631E05CE5F2FDA5DE41CF3A979F32B8407E6D5058FDCED7F7911C463163278FE" },
   { name = "parse_trans", version = "3.3.1", build_tools = ["rebar3"], requirements = [], otp_app = "parse_trans", source = "hex", outer_checksum = "07CD9577885F56362D414E8C4C4E6BDF10D43A8767ABB92D24CBE8B24C54888B" },
   { name = "snag", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "35C63E478782C58236F1050297C2FDF9806A4DD55C6FAF0B6EC5E54BC119342D" },
   { name = "ssl_verify_fun", version = "1.1.6", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680" },
-  { name = "thoas", version = "0.4.0", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "442296847ACA11DB8D25180693D7CA3073D6D7179F66952F07B16415306513B6" },
+  { name = "thoas", version = "0.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "4918D50026C073C4AB1388437132C77A6F6F7C8AC43C60C13758CC0ADCE2134E" },
   { name = "unicode_util_compat", version = "0.7.0", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "25EEE6D67DF61960CF6A794239566599B09E17E668D3700247BC498638152521" },
 ]
 
@@ -30,6 +31,7 @@ gleam_hackney = "~> 0.2"
 gleam_http = "~> 3.1"
 gleam_json = "~> 0.5"
 gleam_otp = "~> 0.5"
-gleam_stdlib = "~> 0.24"
+gleam_stdlib = "~> 0.26"
 gleeunit = "~> 0.6"
+outil = "~> 0.3.3"
 snag = "~> 0.2"

--- a/src/buildogram/util.gleam
+++ b/src/buildogram/util.gleam
@@ -19,10 +19,8 @@ import gleam/int
 import gleam/json
 import gleam/list
 import gleam/option.{Option}
-import gleam/result
 import gleam/string
 import gleam/dynamic
-import snag.{Snag}
 
 /// The sum of all Ints in the given list.
 pub fn sum(l: List(Int)) -> Int {
@@ -98,9 +96,4 @@ pub fn show_response(rep: Response(a)) -> String {
   "HTTP"
   |> string.append(" ")
   |> string.append(int.to_string(rep.status))
-}
-
-/// Transform any error to a new Snag with the given context.
-pub fn snag_context(res: Result(a, b), context: String) -> Result(a, Snag) {
-  result.map_error(res, fn(_) { snag.new(context) })
 }


### PR DESCRIPTION
[Outil](https://hexdocs.pm/outil/) is my own library for building command line utilities. It's in early development and I have to use it myself, Buildogram seemed like a good target.

NOTE: The app will still read the environment variables for backwards compatibility. But now it gets this nice help text:

```
buildogram -- Serve buildogram SVGs on request.

Usage: buildogram

Options:
  -p, --port  Port to listen on (int, default: 3000)
  --cache  HTTP cache size (int, default: 100)
  -h, --help  Show this help text and exit.

```