### PR TITLE
dont scale to runs longer than a week

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "buildogram"
-version = "0.1.0"
+version = "0.1.1"
 
 licences = ["Apache-2.0"]
 description = "An application that displays build pipeline statistics."


### PR DESCRIPTION
This is a workaround for bug #19 

Fixing it will require a lot more changes, but this workaround at least makes the diagrams not useless.

Before:
![Skärmavbild 2024-03-17 kl  11 28 25](https://github.com/fabjan/buildogram/assets/33322/20f5c97b-f33f-4cf2-b69b-282a77b801f9)

After:
![Skärmavbild 2024-03-17 kl  11 28 34](https://github.com/fabjan/buildogram/assets/33322/d823c3fb-7801-46d7-8d00-1971b16e22c3)
